### PR TITLE
fix(freiemodule): don't display freie module on search page without c…

### DIFF
--- a/plugins/freiemodule/lib/freiemoduleplugin_class.php
+++ b/plugins/freiemodule/lib/freiemoduleplugin_class.php
@@ -113,6 +113,10 @@ class freiemodule {
 			$date = date("Y-m-d", time());
 			$menuId = (int)$this->checked->menuid;
 
+			if ($menuId === 1 && isset($_GET['search'])) {
+				return;
+			}
+
 			$sql =
 				"SELECT * ".
 				"FROM {$this->cms->tbname["papoo_freiemodule_daten"]} module ".


### PR DESCRIPTION
…oming from menu entry

When clicking onto the search bar icon without entering any value, on gets redirected to: `/index.php?search=Suche&erw_suchbereich=&getlang=de&menuid=&find=&csrf_token=3d8b233bf9da531b457d3c97d2c0c104`

There is an empty menuid= query string set, which resolved to the startpage with menuid=1. The search module is just shown and below the "freie module" plugin content. This shouldn't be shown in that case.